### PR TITLE
Override default ping settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,19 +40,20 @@ final class MyTest {
 ```
 
 Or if need to override default settings:
+
 ```java
+import com.yegor256.OnlineMeans;
 import com.yegor256.WeAreOnline;
-import com.yegor256.WeAreOnlineOverride;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(WeAreOnline.class)
 final class MyTest {
-  @Test
-  @WeAreOnlineOverride(url = "https://www.amazon.com", connectTimeout = 500, readTimeout = 1500)
-  void canDownloadViaHttp() throws Exception {
-    new URL("https://www.amazon.com").openStream();
-  }
+    @Test
+    @OnlineMeans(url = "https://www.amazon.com", connectTimeout = 500, readTimeout = 1500)
+    void canDownloadViaHttp() throws Exception {
+        new URL("https://www.amazon.com").openStream();
+    }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,23 @@ final class MyTest {
 }
 ```
 
+Or if need to override default settings:
+```java
+import com.yegor256.WeAreOnline;
+import com.yegor256.WeAreOnlineOverride;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(WeAreOnline.class)
+final class MyTest {
+  @Test
+  @WeAreOnlineOverride(url = "https://www.amazon.com", connectTimeout = 500, readTimeout = 1500)
+  void canDownloadViaHttp() throws Exception {
+    new URL("https://www.amazon.com").openStream();
+  }
+}
+```
+
 We don't want this unit test to be executed when no Internet connection
 is available. The `WeAreOnline` execution condition will prevent JUnit5 from
 executing the test when you are offline.

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,12 @@ SOFTWARE.
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-commons</artifactId>
+      <version>1.9.3</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>
       <version>2.2</version>

--- a/src/main/java/com/yegor256/OnlineMeans.java
+++ b/src/main/java/com/yegor256/OnlineMeans.java
@@ -30,13 +30,13 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Override default ping settings.
+ * Override ping options.
  * @author ishchenko
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.METHOD})
-public @interface WeAreOnlineOverride {
+public @interface OnlineMeans {
     /**
      * URL to ping.
      * @return Public URL

--- a/src/main/java/com/yegor256/WeAreOnline.java
+++ b/src/main/java/com/yegor256/WeAreOnline.java
@@ -57,7 +57,7 @@ public final class WeAreOnline implements ExecutionCondition {
     @Override
     public ConditionEvaluationResult evaluateExecutionCondition(
         final ExtensionContext context) {
-        final WeAreOnlineOverride overrides = WeAreOnline.retrieveSettings(context);
+        final OnlineMeans overrides = WeAreOnline.retrieveSettings(context);
         ConditionEvaluationResult ret;
         try {
             if (WeAreOnline.ping(overrides)) {
@@ -88,28 +88,28 @@ public final class WeAreOnline implements ExecutionCondition {
      * @param context Test context
      * @return Settings for ping
      */
-    private static WeAreOnlineOverride retrieveSettings(final ExtensionContext context) {
+    private static OnlineMeans retrieveSettings(final ExtensionContext context) {
         return Optional.ofNullable(context)
             .flatMap(ExtensionContext::getElement)
             .flatMap(
-                element -> AnnotationUtils.findAnnotation(element, WeAreOnlineOverride.class)
+                element -> AnnotationUtils.findAnnotation(element, OnlineMeans.class)
             )
-            .orElse(new DefaultSettings());
+            .orElse(new DefaultOnlineMeans());
     }
 
     /**
      * Ping.
-     * @param overrides Override default ping settings.
+     * @param options Override default ping options.
      * @return TRUE if we are online
      * @throws IOException In case of check failure
      * @since 0.2.0
      */
-    private static boolean ping(final WeAreOnlineOverride overrides) throws IOException {
+    private static boolean ping(final OnlineMeans options) throws IOException {
         boolean online = true;
         try {
-            final URLConnection conn = new URI(overrides.url()).toURL().openConnection();
-            conn.setConnectTimeout(overrides.connectTimeout());
-            conn.setReadTimeout(overrides.readTimeout());
+            final URLConnection conn = new URI(options.url()).toURL().openConnection();
+            conn.setConnectTimeout(options.connectTimeout());
+            conn.setReadTimeout(options.readTimeout());
             conn.connect();
             conn.getInputStream().close();
         } catch (final IOException ignored) {
@@ -121,10 +121,10 @@ public final class WeAreOnline implements ExecutionCondition {
     }
 
     /**
-     * Default settings if WeAreOnlineOverride is not present.
+     * Default options if OnlineMeans is not present.
      * @since 0.2.0
      */
-    private static class DefaultSettings implements Annotation, WeAreOnlineOverride {
+    private static class DefaultOnlineMeans implements Annotation, OnlineMeans {
 
         @Override
         public String url() {
@@ -143,7 +143,7 @@ public final class WeAreOnline implements ExecutionCondition {
 
         @Override
         public Class<? extends Annotation> annotationType() {
-            return WeAreOnlineOverride.class;
+            return OnlineMeans.class;
         }
 
         @Override

--- a/src/main/java/com/yegor256/WeAreOnlineOverride.java
+++ b/src/main/java/com/yegor256/WeAreOnlineOverride.java
@@ -1,0 +1,63 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.yegor256;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Override default ping settings.
+ * @author ishchenko
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface WeAreOnlineOverride {
+    /**
+     * URL to ping.
+     * @return Public URL
+     */
+    String url() default "https://www.google.com";
+
+    /**
+     * Connection timeout.
+     * @return Timeout in milliseconds
+     */
+    int connectTimeout() default 300;
+
+    /**
+     * Read timeout.
+     * @return Timeout in milliseconds
+     */
+    int readTimeout() default 1000;
+
+    /**
+     * Set true if test should run only then offline.
+     * @return Offline mode
+     */
+    boolean offline() default false;
+}

--- a/src/test/java/com/yegor256/WeAreOnlineDefaultContext.java
+++ b/src/test/java/com/yegor256/WeAreOnlineDefaultContext.java
@@ -1,0 +1,152 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.yegor256;
+
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExecutableInvoker;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestInstances;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+/**
+ * Extension context for tests.
+ *
+ * @since 0.2.0
+ */
+final class WeAreOnlineDefaultContext implements ExtensionContext {
+
+    /**
+     * Annotated element for context.
+     */
+    private AnnotatedElement element;
+
+    @Override
+    public Optional<ExtensionContext> getParent() {
+        return Optional.empty();
+    }
+
+    @Override
+    public ExtensionContext getRoot() {
+        return null;
+    }
+
+    @Override
+    public String getUniqueId() {
+        return null;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return null;
+    }
+
+    @Override
+    public Set<String> getTags() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public Optional<AnnotatedElement> getElement() {
+        return Optional.ofNullable(this.element);
+    }
+
+    @Override
+    public Optional<Class<?>> getTestClass() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<TestInstance.Lifecycle> getTestInstanceLifecycle() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Object> getTestInstance() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<TestInstances> getTestInstances() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Method> getTestMethod() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Throwable> getExecutionException() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<String> getConfigurationParameter(final String key) {
+        return Optional.empty();
+    }
+
+    @Override
+    public <T> Optional<T> getConfigurationParameter(final String key,
+        final Function<String, T> transformer) {
+        return Optional.empty();
+    }
+
+    @Override
+    public void publishReportEntry(final Map<String, String> map) {
+        // nothing
+    }
+
+    @Override
+    public Store getStore(final Namespace namespace) {
+        return null;
+    }
+
+    @Override
+    public ExecutionMode getExecutionMode() {
+        return null;
+    }
+
+    @Override
+    public ExecutableInvoker getExecutableInvoker() {
+        return null;
+    }
+
+    /**
+     * Create context with custom annotated element.
+     * @param element Annotated element
+     * @return Context with annotated element
+     */
+    static WeAreOnlineDefaultContext withElement(final AnnotatedElement element) {
+        final WeAreOnlineDefaultContext context = new WeAreOnlineDefaultContext();
+        context.element = element;
+        return context;
+    }
+}

--- a/src/test/java/com/yegor256/WeAreOnlineTest.java
+++ b/src/test/java/com/yegor256/WeAreOnlineTest.java
@@ -72,13 +72,13 @@ final class WeAreOnlineTest {
     }
 
     @SuppressWarnings("unused")
-    @WeAreOnlineOverride(connectTimeout = 1, readTimeout = 1)
+    @OnlineMeans(connectTimeout = 1, readTimeout = 1)
     private void overrideTimeout() {
         // empty method for test override annotation
     }
 
     @SuppressWarnings("unused")
-    @WeAreOnlineOverride(offline = true)
+    @OnlineMeans(offline = true)
     private void overrideOfflineMode() {
         // empty method for test override annotation
     }

--- a/src/test/java/com/yegor256/WeAreOnlineTest.java
+++ b/src/test/java/com/yegor256/WeAreOnlineTest.java
@@ -23,10 +23,13 @@
  */
 package com.yegor256;
 
+import java.lang.reflect.AnnotatedElement;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.platform.commons.util.ReflectionUtils;
 
 /**
  * Test case for {@link WeAreOnline}.
@@ -44,4 +47,39 @@ final class WeAreOnlineTest {
         );
     }
 
+    @Test
+    void checkOfflineStatus() {
+        final AnnotatedElement element = ReflectionUtils.getRequiredMethod(
+            WeAreOnlineTest.class, "overrideTimeout"
+        );
+        final ExtensionContext context = WeAreOnlineDefaultContext.withElement(element);
+        MatcherAssert.assertThat(
+            new WeAreOnline().evaluateExecutionCondition(context).isDisabled(),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void checkInvertOnlineStatus() {
+        final AnnotatedElement element = ReflectionUtils.getRequiredMethod(
+            WeAreOnlineTest.class, "overrideOfflineMode"
+        );
+        final ExtensionContext context = WeAreOnlineDefaultContext.withElement(element);
+        MatcherAssert.assertThat(
+            new WeAreOnline().evaluateExecutionCondition(context).isDisabled(),
+            Matchers.is(true)
+        );
+    }
+
+    @SuppressWarnings("unused")
+    @WeAreOnlineOverride(connectTimeout = 1, readTimeout = 1)
+    private void overrideTimeout() {
+        // empty method for test override annotation
+    }
+
+    @SuppressWarnings("unused")
+    @WeAreOnlineOverride(offline = true)
+    private void overrideOfflineMode() {
+        // empty method for test override annotation
+    }
 }


### PR DESCRIPTION
Primary goals:
1. Sometimes you need to check access to a specific web resource.
2. If the resource is unavailable or takes a long time to respond, then the test should not be run.
3. Sometimes it is necessary to run a test in case of offline.
 
For this goal add `WeAreOnlineOverride` annotation which allows to override default ping address and set connect/read timeout