### PR TITLE
Bump pitest-maven and pitest-junit5-plugin to latest stable versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
       <plugin>
         <groupId>org.pitest</groupId>
         <artifactId>pitest-maven</artifactId>
-        <version>1.17.4</version>
+        <version>1.23.1</version>
         <executions>
           <execution>
             <goals>
@@ -144,7 +144,7 @@
           <dependency>
             <groupId>org.pitest</groupId>
             <artifactId>pitest-junit5-plugin</artifactId>
-            <version>1.2.1</version>
+            <version>1.2.3</version>
           </dependency>
           <dependency>
             <groupId>org.junit.platform</groupId>


### PR DESCRIPTION
@yegor256 this PR upgrades the two mutation-testing plugins to their latest stable versions. All other direct plugins and dependencies in the POM (including jcabi parent `0.73.1`, `revapi-maven-plugin 0.15.1`, `revapi-java 0.28.4`, `qulice-maven-plugin 0.26.0`, `junit-platform-launcher 6.0.3`) were already at the latest stable release. Only JUnit 6.1.0-M1 milestones were available beyond the current set, and they were intentionally skipped per `stable versions` requirement.

### Changes
- `pitest-maven` 1.17.4 -> 1.23.1
- `pitest-junit5-plugin` 1.2.1 -> 1.2.3

### Verification
Full Maven build passed locally with both default and `qulice` profile:

```
mvn --batch-mode clean install -Pqulice
...
[INFO] BUILD SUCCESS
[INFO] Total time: 45.439 s
```

Mutation coverage is still above the `35%` threshold (observed 83%), revapi passes, qulice 0.26.0 passes, and all unit tests pass on JDK 21.

### CI note
The workflow runs on this PR show `action_required` because the fork is treated as a first-time contributor. They cannot run until a maintainer approves them from the Actions tab. Once approved, they should pass since the local run on identical settings succeeded.